### PR TITLE
Add default vscode bash profile

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -27,5 +27,16 @@
   },
   "files.associations": {
     "*.v": "systemverilog"
-  }
+  },
+  "terminal.integrated.profiles.linux": {
+    "c2s2_ip": {
+      "path": "bash",
+      "icon": "terminal-bash",
+      "args": [
+        "--init-file",
+        "${workspaceFolder}/tools/source.sh"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "c2s2_ip"
 }

--- a/tools/source.sh
+++ b/tools/source.sh
@@ -1,0 +1,4 @@
+source ~/.bashrc
+source .venv/bin/activate
+
+echo -e "\033[0;32mC2S2 Workspace Initialized.\033[0m"


### PR DESCRIPTION
Activates `.venv` on terminal creation.